### PR TITLE
Fix experiment index and V2a title consistency

### DIFF
--- a/docs/blog/agentic-bullwhip-v2a.html
+++ b/docs/blog/agentic-bullwhip-v2a.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>sarvam-30b in Supply Chain Ordering: A Comparison with GPT OSS 120B | Industrial Mind &amp; Code</title>
-  <meta name="description" content="sarvam-30b versus GPT OSS 120B on a synthetic Indian automotive demand series. No meaningful difference on any metric. Neither model detected Indian seasonal demand patterns. Exponential smoothing outperformed both by 8x." />
+  <title>Sovereign Model Performance in Stateless Supply Chain Replenishment: sarvam-30b vs. GPT-OSS-120B — Industrial Mind &amp; Code</title>
+  <meta name="description" content="sarvam-30b versus GPT-OSS-120B on a synthetic Indian automotive demand series — 1,440 LLM calls, 10 replications. No meaningful difference on any metric. Neither model detected Indian seasonal demand patterns. Exponential smoothing outperformed both by 8×." />
   <link rel="canonical" href="https://www.industrialmindandcode.ai/blog/agentic-bullwhip-v2a.html" />
   <meta property="og:type" content="article" />
-  <meta property="og:title" content="sarvam-30b in Supply Chain Ordering: A Comparison with GPT OSS 120B | Industrial Mind &amp; Code" />
-  <meta property="og:description" content="sarvam-30b versus GPT OSS 120B on a synthetic Indian automotive demand series. No meaningful difference on any metric. Neither model detected Indian seasonal demand patterns. Exponential smoothing outperformed both by 8x." />
+  <meta property="og:title" content="Sovereign Model Performance in Stateless Supply Chain Replenishment: sarvam-30b vs. GPT-OSS-120B — Industrial Mind &amp; Code" />
+  <meta property="og:description" content="sarvam-30b versus GPT-OSS-120B on a synthetic Indian automotive demand series. No meaningful difference on any metric. Neither model detected Indian seasonal demand patterns. Exponential smoothing outperformed both by 8×." />
   <meta property="og:url" content="https://www.industrialmindandcode.ai/blog/agentic-bullwhip-v2a.html" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -488,9 +488,9 @@
   <header class="post-header">
     <div class="container">
       <p class="post-eyebrow">Supply Chain · Sovereign Model · Experiment Writeup</p>
-      <h1 class="post-title">sarvam-30b in Supply Chain Ordering: A Comparison with GPT OSS 120B</h1>
+      <h1 class="post-title">Sovereign Model Performance in Stateless Supply Chain Replenishment: sarvam-30b vs. GPT-OSS-120B</h1>
       <p class="post-summary">
-        India's sovereign model produced no meaningful difference from GPT OSS 120B on supply chain ordering. Neither model detected Indian seasonal patterns. Exponential smoothing outperformed both by roughly 8x.
+        India's sovereign model showed no practically meaningful difference from GPT OSS in the tested context conditions. I expected it would have more India-specific capabilities.
       </p>
       <div class="post-meta">
         <div class="post-meta-item">
@@ -515,10 +515,10 @@
 
       <!-- Abstract -->
       <div class="post-section">
-        <p class="section-label">TL;DR</p>
+        <p class="section-label">Abstract</p>
         <div class="abstract-block">
-          <p>Agentic Bullwhip Effect Version 2 showed that no LLM configuration could beat a simple exponential smoothing heuristic on supply chain order variance or stockouts. This experiment asked a follow-up question: would a model trained on Indian data show stronger seasonal awareness on an Indian automotive demand series?</p>
-          <p>I tested sarvam-30b (India's sovereign model, 30B total parameters, 2.4B active) against GPT OSS 120B as a reference. The demand series was calibrated to real Indian PV market seasonality: festive peaks, monsoon troughs, fiscal year-end patterns. The agents received the current month name plus four numeric state variables. Any seasonal reasoning would have to come from the model's world knowledge.</p>
+          <p>Version 2 showed that no LLM configuration could beat a simple exponential smoothing heuristic on supply chain order variance or stockouts. This experiment asked a follow-up question: would a model trained on Indian data show stronger seasonal awareness on an Indian automotive demand series?</p>
+          <p>I tested sarvam-30b — India's sovereign model, 30B total parameters, 2.4B active — against GPT OSS 120B as a reference. The demand series was calibrated to real Indian PV market seasonality: festive peaks, monsoon troughs, fiscal year-end patterns. The agents received the current month name plus four numeric state variables. Any seasonal reasoning would have to come from the model's world knowledge.</p>
           <p>The answer: no meaningful difference. sarvam-30b chain OVAR 4.504 vs GPT OSS 120B 4.52. No practically meaningful difference in the tested context conditions. Neither model detected Indian seasonal demand patterns. Exponential smoothing (OVAR 0.54) won by roughly 8x.</p>
           <p>One finding emerged from the integration work: enabling sarvam-30b's native reasoning flag (think=True) was associated with eliminating run-level failures without affecting supply chain outcomes.</p>
         </div>
@@ -538,12 +538,12 @@
             <tr>
               <td>Reference</td>
               <td>gpt-oss:120B</td>
-              <td>Agentic Bullwhip Effect Version 2 results used for comparison; not re-run in Version 2a</td>
+              <td>Version 2 results used for comparison; not re-run in V2a</td>
             </tr>
             <tr>
               <td>Conditions</td>
               <td>E1: context, think=False &middot; E2: context, think=True</td>
-              <td>Blind condition not run. See note below table</td>
+              <td>Blind condition not run — see note below table</td>
             </tr>
             <tr>
               <td>Replications</td>
@@ -607,13 +607,13 @@
         <h2 class="section-title">What I found</h2>
         <ol class="findings-list">
           <li>
-            <span class="finding-text"><strong>No practically meaningful difference in task performance was observed in the tested conditions.</strong> sarvam-30b chain OVAR 4.504 &plusmn; 0.044 (E1) and 4.501 &plusmn; 0.093 (E2). GPT OSS 120B achieved 4.52 &plusmn; 0.05 (Agentic Bullwhip Effect Version 2 context reference; not re-run in Version 2a). The difference is 0.02, well within noise and below the MPRD threshold of 0.5. India's sovereign model did not produce different ordering behaviour in the tested context conditions, despite being trained on Indian data and the demand series being calibrated to Indian market seasonality.</span>
+            <span class="finding-text"><strong>No practically meaningful difference in task performance was observed in the tested conditions.</strong> sarvam-30b chain OVAR 4.504 &plusmn; 0.044 (E1) and 4.501 &plusmn; 0.093 (E2). GPT OSS 120B achieved 4.52 &plusmn; 0.05 (V2 context reference; not re-run in V2a). The difference is 0.02, well within noise and below the MPRD threshold of 0.5. India's sovereign model did not produce different ordering behaviour in the tested context conditions, despite being trained on Indian data and the demand series being calibrated to Indian market seasonality.</span>
           </li>
           <li>
-            <span class="finding-text"><strong>Neither model detected Indian seasonal demand patterns.</strong> Pattern scores: sarvam-30b 0.219&ndash;0.232, GPT OSS 120B 0.21. All identical within noise. The demand series contains two Indian festive cycles with documented peak months, a monsoon trough, and wedding season elevation. Agents received the month name plus four numeric state variables in the user prompt. No event labels, no year. Neither model showed seasonal awareness. Cultural training data did not produce measurably different ordering behaviour on this task.</span>
+            <span class="finding-text"><strong>Neither model detected Indian seasonal demand patterns.</strong> Pattern scores: sarvam-30b 0.219&ndash;0.232, GPT OSS 120B 0.21. All identical within noise. The demand series contains two Indian festive cycles with documented peak months, a monsoon trough, and wedding season elevation. Agents received the month name plus four numeric state variables in the user prompt — no event labels, no year. Neither model showed seasonal awareness. Cultural training data did not produce measurably different ordering behaviour on this task.</span>
           </li>
           <li>
-            <span class="finding-text"><strong>Enabling think=True was associated with eliminating run-level failures without changing supply chain outcomes.</strong> E1 (think=False): 15 of 25 run attempts needed replacement. E2 (think=True): 0 of 10 run attempts needed replacement. Chain OVAR difference between E1 and E2: 0.003. Note: E1 also had a separate API-flag/prompt conflict: the system prompt contained a &ldquo;Think silently&rdquo; instruction that contradicted the think=False flag. The reliability improvement in E2 cannot be fully isolated to the reasoning flag alone. Regardless, think=True produced reliable run completion and is the recommended configuration for local GGUF deployment of sarvam-30b via llama-server.</span>
+            <span class="finding-text"><strong>Enabling think=True was associated with eliminating run-level failures without changing supply chain outcomes.</strong> E1 (think=False): 15 of 25 run attempts needed replacement. E2 (think=True): 0 of 10 run attempts needed replacement. Chain OVAR difference between E1 and E2: 0.003. Note: E1 also had a separate API-flag/prompt conflict &mdash; the system prompt contained a &ldquo;Think silently&rdquo; instruction that contradicted the think=False flag. The reliability improvement in E2 cannot be fully isolated to the reasoning flag alone. Regardless, think=True produced reliable run completion and is the recommended configuration for local GGUF deployment of sarvam-30b via llama-server.</span>
           </li>
           <li>
             <span class="finding-text"><strong>The structural constraint holds.</strong> LLMs are stateless in this architecture: each agent sees the current period&rsquo;s state and places an order with no memory of prior decisions. Exponential smoothing carries one number forward and partially self-corrects. The LLM agent cannot. The current results are consistent with an architectural bottleneck: stateless agents cannot self-correct across periods regardless of training data. Whether cultural training or model size would change outcomes in a stateful architecture is outside what this experiment can establish.</span>
@@ -684,7 +684,7 @@
                 <td class="value-cell best">0 / 10 attempts</td>
               </tr>
               <tr>
-                <td>gpt-oss:120B (Version 2 reference)</td>
+                <td>gpt-oss:120B (V2 reference)</td>
                 <td class="value-cell neutral">4.52 &plusmn; 0.05</td>
                 <td class="value-cell neutral">39.6</td>
                 <td class="value-cell neutral">0.21</td>
@@ -723,7 +723,7 @@
             <tr>
               <td>Blind condition structural failure</td>
               <td>Minimal prompts (no context, no tier persona) produced ~20% per-call error rates. Individual smoke runs at temp=1.0 did complete. A calibration pass produced 0/3 before being stopped. 10-run completion not feasible.</td>
-              <td>Not resolved. Context conditions used for all main runs. Blind condition not directly comparable to Version 2 blind results.</td>
+              <td>Not resolved. Context conditions used for all main runs. Blind condition not directly comparable to V2 blind results.</td>
             </tr>
           </tbody>
         </table>
@@ -741,19 +741,8 @@
         <div class="prose">
           <p>The seasonal awareness hypothesis was not confirmed. I expected that a model with Indian training data would show different ordering behaviour on a demand series calibrated to Indian market seasonality. It did not.</p>
           <p>The agents received the current month name plus four numeric state variables. No event labels, no seasonal context, no year. Any seasonal signal would have to come from the model's world knowledge about what October and November mean in India. Neither sarvam-30b nor GPT OSS showed it. Pattern scores of 0.22 and 0.21 indicate very low, approximately equal, seasonal sensitivity in both models.</p>
-          <p>One possible explanation: the task framing as a supply chain ordering problem may not activate seasonal world knowledge, even when the model possesses it. Whether the model draws on broader seasonal knowledge when asked to make an inventory decision (rather than a factual question about seasonality) is unclear from these results alone.</p>
+          <p>One possible explanation: the task framing as a supply chain ordering problem may not activate seasonal world knowledge, even when the model possesses it. Whether the model draws on broader seasonal knowledge when asked to make an inventory decision — rather than a factual question about seasonality — is unclear from these results alone.</p>
           <p>The structural argument also applies. Stateless agents without memory cannot self-correct drift regardless of what they know about seasonality. Even if a model correctly anticipated a festive peak in period 14, it cannot carry that anticipation forward without memory of what it planned.</p>
-        </div>
-      </div>
-
-      <!-- Industry Implications -->
-      <div class="post-section">
-        <p class="section-label">Industry Implications</p>
-        <h2 class="section-title">What this means for practitioners</h2>
-        <div class="prose">
-          <p>A model trained on Indian data does not automatically use that knowledge when asked to place a supply chain order. sarvam-30b received an Indian demand series and the current month name but showed no seasonal sensitivity. If seasonal awareness matters for your use case, you need to build it into the prompt or the system design explicitly. You cannot assume a model will apply its training knowledge to an operational task just because the task is in the same domain.</p>
-          <p>If you are running sarvam-30b locally via llama-server, use think=True. It removed all run-level failures in this experiment with no downside. Do not use cloud temperature settings for a local GGUF model. Use what the model card specifies (temperature 1.0 in this case).</p>
-          <p>A model that fails consistently is actually easier to deal with than one that fails unpredictably. When a model errors out on some runs and not others with no clear pattern, you have a harder problem: you cannot rely on the output without checking it each time. Run your own reliability tests under the specific conditions you plan to deploy, rather than inferring reliability from benchmark scores.</p>
         </div>
       </div>
 
@@ -779,7 +768,7 @@
       <div class="post-section">
         <div class="method-callout">
           <p class="method-callout-label">Scope and limitations</p>
-          <p>Context conditions only. Blind results not available for sarvam-30b. 10 runs per condition; Agentic Bullwhip Effect Version 2 used 20, so confidence intervals are wider here. Single product, single supply chain structure, fixed deterministic lead times. Stateless agents only, no inter-tier communication. Integration findings are specific to local GGUF deployment via llama-server; cloud API deployment is a different integration surface. Results should not be generalised to supply chain management broadly.</p>
+          <p>Context conditions only. Blind results not available for sarvam-30b. 10 runs per condition — Version 2 used 20, so confidence intervals are wider here. Single product, single supply chain structure, fixed deterministic lead times. Stateless agents only, no inter-tier communication. Integration findings are specific to local GGUF deployment via llama-server; cloud API deployment is a different integration surface. Results should not be generalised to supply chain management broadly.</p>
           <p>All scenarios, companies, products, and supply chain structures are fictional. The demand series is calibrated to real Indian PV market data but is synthetic. No proprietary data was used.</p>
         </div>
       </div>

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Experiments | Industrial Mind &amp; Code</title>
-  <meta name="description" content="Experimental research on LLM agent performance in industrial engineering decision environments: supply chain, maintenance, and production planning, evaluated against deterministic analytical baselines." />
+  <title>Experiments — Industrial Mind &amp; Code</title>
+  <meta name="description" content="Experimental research on LLM agent performance in industrial engineering decision environments — supply chain, maintenance, and production planning, evaluated against deterministic analytical baselines." />
   <link rel="canonical" href="https://www.industrialmindandcode.ai/blog/" />
   <meta property="og:type" content="website" />
-  <meta property="og:title" content="Experiments | Industrial Mind &amp; Code" />
-  <meta property="og:description" content="Experimental research on LLM agent performance in industrial engineering decision environments: supply chain, maintenance, and production planning, evaluated against deterministic analytical baselines." />
+  <meta property="og:title" content="Experiments — Industrial Mind &amp; Code" />
+  <meta property="og:description" content="Experimental research on LLM agent performance in industrial engineering decision environments — supply chain, maintenance, and production planning, evaluated against deterministic analytical baselines." />
   <meta property="og:url" content="https://www.industrialmindandcode.ai/blog/" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -323,110 +323,22 @@
 
       <div class="post-list">
 
-        <!-- V6: Adaptive Alpha — First positive result -->
-        <div class="post-card">
-          <div class="post-card-header">
-            <span class="post-title">The Architecture That Finally Worked: Adaptive Smoothing in Supply Chain Replenishment</span>
-            <span class="post-date">April 2026</span>
-          </div>
-          <p class="post-domain">SUPPLY CHAIN &middot; ADAPTIVE SMOOTHING &middot; EXPERIMENT WRITEUP</p>
-          <p class="post-description">
-            For the first time in this research program, every AI condition produced OVAR below 1.0 &mdash; the AI was damping variance, not amplifying it. The key architectural change: the AI now controls the EMA smoothing parameter &alpha; inside the formula rather than a safety stock buffer on top of it. Best result: GPT OSS 120B blind, OVAR 0.535, marginally beating the fixed &alpha;=0.3 baseline at 0.545.
-          </p>
-          <div class="post-links">
-            <a class="post-link" href="agentic-bullwhip-v6.html">
-              Read
-              <svg viewBox="0 0 10 10" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M1 9L9 1M9 1H3M9 1v6"/></svg>
-            </a>
-            <a class="post-link" href="https://github.com/SiddharthSrinivasan89/industrial-mind-and-code/tree/main/experiments/Agentic_Bullwhip_Effect_V6_StatelessSwing" target="_blank" rel="noopener">
-              GitHub
-              <svg viewBox="0 0 10 10" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M1 9L9 1M9 1H3M9 1v6"/></svg>
-            </a>
-          </div>
-        </div>
-
-        <!-- V5: Research Program Close -->
-        <div class="post-card">
-          <div class="post-card-header">
-            <span class="post-title">The Ceiling Is in the Formula: Oracle Labels and the End of the Research Program</span>
-            <span class="post-date">April 2026</span>
-          </div>
-          <p class="post-domain">SUPPLY CHAIN &middot; ORACLE ABLATION &middot; EXPERIMENT WRITEUP</p>
-          <p class="post-description">
-            Perfect ground-truth labels, fed directly to the architecture with no LLM at all, produced worse OVAR than the Order-Up-To formula running alone. Fourteen architectural variants tested. None passed the gate. The 0.540-unit gap to exponential smoothing is preserved exactly regardless of label quality, multiplier range, or formula variant. Five versions. One definitive answer.
-          </p>
-          <div class="post-links">
-            <a class="post-link" href="agentic-bullwhip-v5.html">
-              Read
-              <svg viewBox="0 0 10 10" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M1 9L9 1M9 1H3M9 1v6"/></svg>
-            </a>
-            <a class="post-link" href="https://github.com/SiddharthSrinivasan89/industrial-mind-and-code/tree/main/experiments/Agentic_Bullwhip_Effect_V5_ControlArch" target="_blank" rel="noopener">
-              GitHub
-              <svg viewBox="0 0 10 10" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M1 9L9 1M9 1H3M9 1v6"/></svg>
-            </a>
-          </div>
-        </div>
-
-        <!-- V4: Equaliser Effect -->
-        <div class="post-card">
-          <div class="post-card-header">
-            <span class="post-title">The Equaliser Effect: Intent Classification in Supply Chain Replenishment</span>
-            <span class="post-date">April 2026</span>
-          </div>
-          <p class="post-domain">SUPPLY CHAIN &middot; INTENT CLASSIFICATION &middot; EXPERIMENT WRITEUP</p>
-          <p class="post-description">
-            Four AI models &mdash; from a lightweight fast model to a 120-billion-parameter reasoning behemoth &mdash; produced statistically identical supply chain outcomes across three information conditions. Replacing the AI&rsquo;s float output with five discrete text labels fixed the calibration problem from V3b. It simultaneously created a structural ceiling no model or prompt can escape.
-          </p>
-          <div class="post-links">
-            <a class="post-link" href="agentic-bullwhip-v4.html">
-              Read
-              <svg viewBox="0 0 10 10" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M1 9L9 1M9 1H3M9 1v6"/></svg>
-            </a>
-            <a class="post-link" href="https://github.com/SiddharthSrinivasan89/industrial-mind-and-code/tree/main/experiments/Agentic_Bullwhip_Effect_V4_WorldEvents" target="_blank" rel="noopener">
-              GitHub
-              <svg viewBox="0 0 10 10" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M1 9L9 1M9 1H3M9 1v6"/></svg>
-            </a>
-          </div>
-        </div>
-
-        <!-- V3b: Hybrid Architecture -->
-        <div class="post-card">
-          <div class="post-card-header">
-            <span class="post-title">Hybrid AI Safety Stock Control in Supply Chain Replenishment</span>
-            <span class="post-date">April 2026</span>
-          </div>
-          <p class="post-domain">SUPPLY CHAIN &middot; HYBRID ARCHITECTURE &middot; EXPERIMENT WRITEUP</p>
-          <p class="post-description">
-            Three AI models controlled the safety stock multiplier in a hybrid architecture; a mathematical formula handled the order quantity. All four hypotheses failed across three information conditions and 20 replications per condition. Every AI condition produced higher order variance than doing nothing. Context made two out of three models worse. Memory caused the advanced reasoning model to collapse.
-          </p>
-          <div class="post-links">
-            <a class="post-link" href="agentic-bullwhip-v3b.html">
-              Read
-              <svg viewBox="0 0 10 10" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M1 9L9 1M9 1H3M9 1v6"/></svg>
-            </a>
-            <a class="post-link" href="https://github.com/SiddharthSrinivasan89/industrial-mind-and-code/tree/main/experiments/Agentic_Bullwhip_Effect_V3b_HybridArch" target="_blank" rel="noopener">
-              GitHub
-              <svg viewBox="0 0 10 10" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M1 9L9 1M9 1H3M9 1v6"/></svg>
-            </a>
-          </div>
-        </div>
-
         <!-- V2a: sarvam-30b -->
         <div class="post-card">
           <div class="post-card-header">
-            <span class="post-title">sarvam-30b in Supply Chain Ordering: A Comparison with GPT OSS 120B</span>
+            <span class="post-title">Sovereign Model Performance in Stateless Supply Chain Replenishment: sarvam-30b vs. GPT-OSS-120B</span>
             <span class="post-date">March 2026</span>
           </div>
           <p class="post-domain">SUPPLY CHAIN &middot; SOVEREIGN MODEL &middot; EXPERIMENT WRITEUP</p>
           <p class="post-description">
-            India&rsquo;s sovereign model showed no measurable difference from GPT OSS on this task: OVAR 4.504 vs. 4.52. Neither model detected Indian seasonal demand patterns. Exponential smoothing outperformed both by approximately 8&times;. The GPT OSS result is an Agentic Bullwhip Effect Version 2 context reference, not a co-run comparison.
+            India&rsquo;s sovereign model showed no measurable difference from GPT OSS on this task &mdash; OVAR 4.504 vs. 4.52. Neither model detected Indian seasonal demand patterns. Exponential smoothing outperformed both by approximately 8&times;. The GPT OSS result is a V2 context reference, not a co-run comparison.
           </p>
           <div class="post-links">
             <a class="post-link" href="agentic-bullwhip-v2a.html">
               Read
               <svg viewBox="0 0 10 10" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M1 9L9 1M9 1H3M9 1v6"/></svg>
             </a>
-            <a class="post-link" href="https://github.com/SiddharthSrinivasan89/industrial-mind-and-code/tree/main/Agentic_Bullwhip_Effect_Version_2a" target="_blank" rel="noopener">
+            <a class="post-link" href="https://github.com/SiddharthSrinivasan89/industrial-mind-and-code/tree/main/experiments/Agentic_Bullwhip_Effect_Version_2a" target="_blank" rel="noopener">
               GitHub
               <svg viewBox="0 0 10 10" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M1 9L9 1M9 1H3M9 1v6"/></svg>
             </a>
@@ -436,7 +348,7 @@
         <!-- V2: Heuristic Dominance -->
         <div class="post-card">
           <div class="post-card-header">
-            <span class="post-title">LLM Agents Against Heuristic Baselines in Supply Chain Replenishment: An Experimental Comparison</span>
+            <span class="post-title">Heuristic Dominance Over LLM Agents in Stateless Linear Supply Chain Replenishment: An Experimental Study</span>
             <span class="post-date">March 2026</span>
           </div>
           <p class="post-domain">SUPPLY CHAIN &middot; EXPERIMENT WRITEUP</p>
@@ -458,19 +370,19 @@
         <!-- V1: Inverted Cascade -->
         <div class="post-card">
           <div class="post-card-header">
-            <span class="post-title">Context and Model Capability in AI-Driven Supply Chain Ordering: An Experimental Study</span>
+            <span class="post-title">Context &times; Model Interactions in LLM-Driven Supply Chain Ordering: An Inverted Bullwhip Cascade</span>
             <span class="post-date">February 2026</span>
           </div>
           <p class="post-domain">SUPPLY CHAIN &middot; EXPERIMENT WRITEUP</p>
           <p class="post-description">
-            All four configurations amplified demand variability. The context &times; reasoning condition produced a fully inverted tier pattern (OEM as the noisiest tier, Component as the quietest), reversing the standard upstream cascade.
+            All four configurations amplified demand variability. The context &times; reasoning condition produced a fully inverted tier pattern &mdash; OEM as the noisiest tier, Component as the quietest &mdash; reversing the standard upstream cascade.
           </p>
           <div class="post-links">
             <a class="post-link" href="agentic-bullwhip-v1.html">
               Read
               <svg viewBox="0 0 10 10" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M1 9L9 1M9 1H3M9 1v6"/></svg>
             </a>
-            <a class="post-link" href="https://github.com/SiddharthSrinivasan89/industrial-mind-and-code/tree/main/agentic_bullwhip_effect_version_1" target="_blank" rel="noopener">
+            <a class="post-link" href="https://github.com/SiddharthSrinivasan89/industrial-mind-and-code/tree/main/experiments/Agentic_Bullwhip_Effect_Version_1" target="_blank" rel="noopener">
               GitHub
               <svg viewBox="0 0 10 10" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M1 9L9 1M9 1H3M9 1v6"/></svg>
             </a>


### PR DESCRIPTION
## Summary
Fixes the stale published-experiments index and aligns the V2a write-up title with the actual experiment title.

## Changes
- remove stale V3b/V4/V5/V6 published experiment entries that do not match the current repository experiment set
- restore the published experiment index to the actual experiments present in the repo: V1, V2, and V2a
- fix the V2a blog index GitHub link
- fix the V1 blog index GitHub link
- align the V2a page title and visible heading with the actual experiment title used elsewhere in the repo

## Why
The current `main` branch still showed stale index copy including `V5` wording about the "end of the research program," which no longer matches the actual experiment directories in the repository.